### PR TITLE
Support separate CAA and EAA access keys

### DIFF
--- a/config.default.ini
+++ b/config.default.ini
@@ -9,8 +9,10 @@ dbname=musicbrainz_db
 
 [s3]
 url=https://{bucket}.s3.us.archive.org/{file}
-access=
-secret=
+caa_access=
+caa_secret=
+eaa_access=
+eaa_secret=
 
 [sentry]
 dsn=

--- a/config.tests.example.ini
+++ b/config.tests.example.ini
@@ -10,5 +10,7 @@ dbname=musicbrainz_test_artwork_indexer
 
 [s3]
 url=http://{bucket}.s3.example.com/{file}
-access=user
-secret=pass
+caa_access=caa_user
+caa_secret=caa_pass
+eaa_access=eaa_user
+eaa_secret=eaa_pass

--- a/docker/config.ini.ctmpl
+++ b/docker/config.ini.ctmpl
@@ -15,5 +15,7 @@ dbname={{ keyOrDefault (print $key_prefix "postgres_database") "musicbrainz_db" 
 
 [s3]
 url={{ keyOrDefault (print $key_prefix "s3_url") "https://{bucket}.s3.us.archive.org/{file}" }}
-access={{ keyOrDefault (print $key_prefix "s3_access_key") "" }}
-secret={{ keyOrDefault (print $key_prefix "s3_secret_key") "" }}
+caa_access={{ keyOrDefault (print $key_prefix "caa_s3_access_key") "" }}
+caa_secret={{ keyOrDefault (print $key_prefix "caa_s3_secret_key") "" }}
+eaa_access={{ keyOrDefault (print $key_prefix "eaa_s3_access_key") "" }}
+eaa_secret={{ keyOrDefault (print $key_prefix "eaa_s3_secret_key") "" }}

--- a/generate_code.py
+++ b/generate_code.py
@@ -443,6 +443,10 @@ for project in PROJECTS:
                 return '{project['ia_collection']}'
 
             @property
+            def project_abbr(self):
+                return '{project['abbr']}'
+
+            @property
             def ws_inc_params(self):
                 return '{project['ws_inc_params']}'
 

--- a/handlers.py
+++ b/handlers.py
@@ -22,6 +22,10 @@ class ReleaseEventHandler(MusicBrainzEventHandler):
         return 'coverartarchive'
 
     @property
+    def project_abbr(self):
+        return 'caa'
+
+    @property
     def ws_inc_params(self):
         return 'artists'
 
@@ -43,6 +47,10 @@ class EventEventHandler(MusicBrainzEventHandler):
     @property
     def ia_collection(self):
         return 'eventartarchive'
+
+    @property
+    def project_abbr(self):
+        return 'eaa'
 
     @property
     def ws_inc_params(self):

--- a/handlers_base.py
+++ b/handlers_base.py
@@ -66,12 +66,17 @@ class EventHandler:
     def ia_collection(self):
         raise NotImplementedError
 
+    @property
+    def project_abbr(self):
+        raise NotImplementedError
+
     def build_authorization_header(self):
+        abbr = self.project_abbr
         s3_conf = self.config['s3']
         return {
             'authorization': 'LOW %s:%s' % (
-                s3_conf['access'],
-                s3_conf['secret'],
+                s3_conf[abbr + '_access'],
+                s3_conf[abbr + '_secret'],
             ),
         }
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,12 +21,13 @@ MBS_TEST_URL = tests_config['musicbrainz']['url']
 
 def image_copy_put(
         project, source_mbid, target_mbid, image_id):
+    abbr = project['abbr']
     return {
         'method': 'PUT',
         'url': f'http://mbid-{target_mbid}.s3.example.com/' +
                f'mbid-{target_mbid}-{image_id}.jpg',
         'headers': {
-            'authorization': 'LOW user:pass',
+            'authorization': f'LOW {abbr}_user:{abbr}_pass',
             'x-amz-copy-source': f'/mbid-{source_mbid}/' +
                                  f'mbid-{source_mbid}-{image_id}.jpg',
             'x-archive-auto-make-bucket': '1',
@@ -51,6 +52,7 @@ def index_event(mbid, **kwargs):
 
 
 def index_json_put(project, mbid, images):
+    abbr = project['abbr']
     entity_type = project['entity_table']
     image_loc = f"https://{project['domain']}/{entity_type}/{mbid}"
 
@@ -58,7 +60,7 @@ def index_json_put(project, mbid, images):
         'method': 'PUT',
         'url': f'http://mbid-{mbid}.s3.example.com/index.json',
         'headers': {
-            'authorization': 'LOW user:pass',
+            'authorization': f'LOW {abbr}_user:{abbr}_pass',
             'content-type': 'application/json; charset=UTF-8',
             'x-archive-auto-make-bucket': '1',
             'x-archive-keep-old-version': '1',
@@ -97,12 +99,13 @@ def mb_metadata_xml_get(project, mbid):
 
 
 def mb_metadata_xml_put(project, mbid, xml):
+    abbr = project['abbr']
     return {
         'method': 'PUT',
         'url': f'http://mbid-{mbid}.s3.example.com/' +
                f'mbid-{mbid}_mb_metadata.xml',
         'headers': {
-            'authorization': 'LOW user:pass',
+            'authorization': f'LOW {abbr}_user:{abbr}_pass',
             'content-type': 'application/xml; charset=UTF-8',
             'x-archive-auto-make-bucket': '1',
             'x-archive-meta-collection': project['ia_collection'],

--- a/tests/test_caa.py
+++ b/tests/test_caa.py
@@ -311,7 +311,7 @@ class TestCoverArtArchive(TestArtArchive):
                        f'mbid-{RELEASE1_MBID}-1.jpg',
                 'data': None,
                 'headers': {
-                    'authorization': 'LOW user:pass',
+                    'authorization': 'LOW caa_user:caa_pass',
                     'x-archive-cascade-delete': '1',
                     'x-archive-keep-old-version': '1',
                 },
@@ -533,7 +533,7 @@ class TestCoverArtArchive(TestArtArchive):
                        f'mbid-{RELEASE1_MBID}-1.jpg',
                 'data': None,
                 'headers': {
-                    'authorization': 'LOW user:pass',
+                    'authorization': 'LOW caa_user:caa_pass',
                     'x-archive-cascade-delete': '1',
                     'x-archive-keep-old-version': '1',
                 },
@@ -546,7 +546,7 @@ class TestCoverArtArchive(TestArtArchive):
                 'url': f'http://mbid-{RELEASE1_MBID}.s3.example.com/' +
                        'index.json',
                 'headers': {
-                    'authorization': 'LOW user:pass',
+                    'authorization': 'LOW caa_user:caa_pass',
                     'x-archive-keep-old-version': '1',
                     'x-archive-cascade-delete': '1',
                 },

--- a/tests/test_eaa.py
+++ b/tests/test_eaa.py
@@ -249,7 +249,7 @@ class TestEventArtArchive(TestArtArchive):
                        f'mbid-{EVENT1_MBID}-1.jpg',
                 'data': None,
                 'headers': {
-                    'authorization': 'LOW user:pass',
+                    'authorization': 'LOW eaa_user:eaa_pass',
                     'x-archive-cascade-delete': '1',
                     'x-archive-keep-old-version': '1',
                 },
@@ -427,7 +427,7 @@ class TestEventArtArchive(TestArtArchive):
                        f'mbid-{EVENT1_MBID}-1.jpg',
                 'data': None,
                 'headers': {
-                    'authorization': 'LOW user:pass',
+                    'authorization': 'LOW eaa_user:eaa_pass',
                     'x-archive-cascade-delete': '1',
                     'x-archive-keep-old-version': '1',
                 },
@@ -442,7 +442,7 @@ class TestEventArtArchive(TestArtArchive):
                 'method': 'DELETE',
                 'url': f'http://mbid-{EVENT1_MBID}.s3.example.com/index.json',
                 'headers': {
-                    'authorization': 'LOW user:pass',
+                    'authorization': 'LOW eaa_user:eaa_pass',
                     'x-archive-keep-old-version': '1',
                     'x-archive-cascade-delete': '1',
                 },


### PR DESCRIPTION
The CAA and EAA actually use different IA credentials to manage their collections.

This splits the current configuration options into per-project ones.